### PR TITLE
fix: useCircularDrag sometimes references old functions

### DIFF
--- a/src/useCircularDrag.ts
+++ b/src/useCircularDrag.ts
@@ -1,23 +1,23 @@
-import { MouseEvent, TouchEvent, useEffect, RefObject, useState } from 'react'
+import { MouseEvent, TouchEvent, useEffect, RefObject, useState, useCallback } from 'react'
 import { useCircularInputContext } from './'
 
 export function useCircularDrag(ref: RefObject<SVGElement | null>) {
 	const { onChange, getValueFromPointerEvent } = useCircularInputContext()
 	const [isDragging, setDragging] = useState(false)
 
-	const handleStart = (e: MouseEvent | TouchEvent) => {
+	const handleStart = useCallback((e: MouseEvent | TouchEvent) => {
 		if (!onChange) return
 		stopEvent(e)
 		setDragging(true)
 		const nearestValue = getValueFromPointerEvent(e)
 		onChange(nearestValue)
-	}
+	}, [onChange])
 
-	const handleMove = (e: MouseEvent | TouchEvent) => {
+	const handleMove = useCallback((e: MouseEvent | TouchEvent) => {
 		stopEvent(e)
 		const nearestValue = getValueFromPointerEvent(e)
 		onChange(nearestValue)
-	}
+	}, [onChange])
 
 	const handleEnd = (e: MouseEvent | TouchEvent) => {
 		stopEvent(e)
@@ -32,7 +32,7 @@ export function useCircularDrag(ref: RefObject<SVGElement | null>) {
 			if (!ref.current) return
 			removeStartListeners(ref.current, handleStart)
 		}
-	}, [ref])
+	}, [ref, handleStart])
 
 	useEffect(() => {
 		if (!isDragging) return
@@ -40,7 +40,7 @@ export function useCircularDrag(ref: RefObject<SVGElement | null>) {
 		return () => {
 			removeListeners(handleMove, handleEnd)
 		}
-	}, [isDragging])
+	}, [isDragging, handleMove])
 
 	return { isDragging }
 }

--- a/src/useCircularDrag.ts
+++ b/src/useCircularDrag.ts
@@ -11,13 +11,13 @@ export function useCircularDrag(ref: RefObject<SVGElement | null>) {
 		setDragging(true)
 		const nearestValue = getValueFromPointerEvent(e)
 		onChange(nearestValue)
-	}, [onChange])
+	}, [onChange, stopEvent, setDragging, getValueFromPointerEvent])
 
 	const handleMove = useCallback((e: MouseEvent | TouchEvent) => {
 		stopEvent(e)
 		const nearestValue = getValueFromPointerEvent(e)
 		onChange(nearestValue)
-	}, [onChange])
+	}, [onChange, stopEvent, getValueFromPointerEvent])
 
 	const handleEnd = (e: MouseEvent | TouchEvent) => {
 		stopEvent(e)


### PR DESCRIPTION
The way these events were getting bound would cause previous values of `onChange` to get called in handleStart and handleMove.