### PR TITLE
Remove height and width properties from <svg> to achieve responsiveness

### DIFF
--- a/src/CircularInput.tsx
+++ b/src/CircularInput.tsx
@@ -176,8 +176,6 @@ export function CircularInput({
 			<svg
 				{...props}
 				ref={containerRef}
-				width={size}
-				height={size}
 				viewBox={`0 0 ${size} ${size}`}
 				style={style}
 				onClick={handleClick}


### PR DESCRIPTION
If the <svg> element is created with a fixed width and height, it is not possible to achieve responsiveness via css classess, so I propose to remove these properties.