### PR TITLE
Fix a bug in utils.ts that crashes the page when mouse reaches left edge of the page

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -98,7 +98,7 @@ export function absPos(e: TouchEvent | MouseEvent) {
 				(window.scrollY || window.pageYOffset),
 		}
 	}
-	const mouseEvent = (e as MouseEvent).pageX && (e as MouseEvent)
+	const mouseEvent = (e as MouseEvent).pageX ?? (e as MouseEvent)
 	if (mouseEvent) {
 		return {
 			x: mouseEvent.pageX - (window.scrollX || window.pageXOffset),


### PR DESCRIPTION
Currently, the page will crash when users interact with the circular input and their mouse cursors touches the left edge of the webpage (pageX = 0). `e.pageX` will be treated as a falsy value when `e.pageX=0`. However, 0 is a perfectly valid value. 

`??` ensures that only undefined `e.pageX` will result in an error.
